### PR TITLE
remove ==0.17 rerun pin to >=0.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = [
   "rerun-viewer",
 ]
 # Add dependencies here
-dependencies = ["gradio>=4.0,<5.0", "rerun-sdk==0.17.0", "opencv-python"]
+dependencies = ["gradio>=4.0,<5.0", "rerun-sdk>=0.17.0", "opencv-python"]
 classifiers = [
   'Development Status :: 3 - Alpha',
   'Operating System :: OS Independent',


### PR DESCRIPTION
With Rerun currently at 0.18.2 I updated the requirements to allow newer versions. I verified with @jleibs that this would work and nothing had changed and he recommended we only lower bound and not pin!